### PR TITLE
Prerelease fixes, part #1

### DIFF
--- a/src/main/scala/main.scala
+++ b/src/main/scala/main.scala
@@ -86,7 +86,7 @@ object main extends ZIOAppDefault {
       JdbcTableManager.layer)
       .catchAllTrace {
         case (e, trace) =>
-          logger.error("Application failed", e)
+          logger.error(s"Application failed: ${e.getMessage}", e)
           ZIO.fail(e)
       }
 }

--- a/src/main/scala/services/app/TableManager.scala
+++ b/src/main/scala/services/app/TableManager.scala
@@ -64,7 +64,7 @@ class JdbcTableManager(options: JdbcConsumerOptions,
     yield result
 
   def cleanupStagingTables: Task[Unit] =
-    val sql = s"SHOW TABLES FROM ${streamContext.stagingCatalog} LIKE '${streamContext.stagingTableNamePrefix}%'"
+    val sql = s"SHOW TABLES FROM ${streamContext.stagingCatalog} LIKE '${streamContext.stagingTableNamePrefix}_%'"
     val statement = ZIO.attemptBlocking {
       sqlConnection.prepareStatement(sql)
     }

--- a/src/main/scala/services/clients/JdbcConsumer.scala
+++ b/src/main/scala/services/clients/JdbcConsumer.scala
@@ -1,10 +1,10 @@
 package com.sneaksanddata.arcane.microsoft_synapse_link
 package services.clients
 
-import com.sneaksanddata.arcane.framework.services.consumers.{JdbcConsumerOptions, StagedVersionedBatch}
+import models.app.ArchiveTableSettings
 import services.clients.{BatchArchivationResult, JdbcConsumer}
 
-import com.sneaksanddata.arcane.microsoft_synapse_link.models.app.ArchiveTableSettings
+import com.sneaksanddata.arcane.framework.services.consumers.{JdbcConsumerOptions, StagedVersionedBatch}
 import org.slf4j.{Logger, LoggerFactory}
 import zio.{Schedule, Task, ZIO, ZLayer}
 
@@ -41,8 +41,6 @@ class JdbcConsumer[Batch <: StagedVersionedBatch](options: JdbcConsumerOptions,
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
   private lazy val sqlConnection: Connection = DriverManager.getConnection(options.connectionUrl)
 
-  val retryPolicy = Schedule.exponential(Duration.ofSeconds(1)) && Schedule.recurs(5)
-  
   def getPartitionValues(batchName: String, partitionFields: List[String]): Future[Map[String, List[String]]] =
     Future.sequence(partitionFields
       .map(partitionField =>
@@ -54,7 +52,7 @@ class JdbcConsumer[Batch <: StagedVersionedBatch](options: JdbcConsumerOptions,
 
   
   def applyBatch(batch: Batch): Task[BatchApplicationResult] =
-    val ack = ZIO.attemptBlocking({ sqlConnection.prepareStatement(batch.batchQuery.query) }) retry  retryPolicy
+    val ack = ZIO.attemptBlocking({ sqlConnection.prepareStatement(batch.batchQuery.query) }) 
     ZIO.acquireReleaseWith(ack)(st => ZIO.succeed(st.close())){ statement =>
       for
         applicationResult <- ZIO.attemptBlocking{ statement.execute() }

--- a/src/main/scala/services/clients/JdbcConsumer.scala
+++ b/src/main/scala/services/clients/JdbcConsumer.scala
@@ -61,7 +61,9 @@ class JdbcConsumer[Batch <: StagedVersionedBatch](options: JdbcConsumerOptions,
       yield applicationResult
     }
 
-  def archiveBatch(batch: Batch): Task[BatchArchivationResult] = executeArchivationQuery(batch).map(_ => new BatchArchivationResult)
+  def archiveBatch(batch: Batch): Task[BatchArchivationResult] =
+    for _ <- executeArchivationQuery(batch)
+    yield new BatchArchivationResult
 
   def optimizeTarget(tableName: String, batchNumber: Long, optimizeThreshold: Long, fileSizeThreshold: String): Task[BatchApplicationResult] =
     if (batchNumber+1) % optimizeThreshold == 0 then
@@ -106,7 +108,7 @@ class JdbcConsumer[Batch <: StagedVersionedBatch](options: JdbcConsumerOptions,
       ZIO.succeed(false)
 
   private def executeArchivationQuery(batch: Batch): Task[BatchArchivationResult] =
-    val expression = s"${batch.archiveExpr(archiveTableSettings.archiveTableFullName)}; DROP TABLE ${batch.name}"
+    val expression = batch.archiveExpr(archiveTableSettings.archiveTableFullName)
     val ack = ZIO.blocking {
       ZIO.succeed(sqlConnection.prepareStatement(expression))
     }
@@ -118,7 +120,7 @@ class JdbcConsumer[Batch <: StagedVersionedBatch](options: JdbcConsumerOptions,
       yield new BatchArchivationResult
     }
 
-  private def dropTempTable(batch: Batch): Task[BatchArchivationResult] =
+  def dropTempTable(batch: Batch): Task[BatchArchivationResult] =
     val ack = ZIO.blocking {
       ZIO.succeed(sqlConnection.prepareStatement(s"DROP TABLE ${batch.name}"))
     }

--- a/src/main/scala/services/graph_builder/VersionedDataGraphBuilder.scala
+++ b/src/main/scala/services/graph_builder/VersionedDataGraphBuilder.scala
@@ -47,7 +47,7 @@ class VersionedDataGraphBuilder(versionedDataGraphBuilderSettings: VersionedData
   def consume: ZSink[Any, Throwable, Chunk[DataStreamElement], Any, Unit] = batchConsumer.consume
 
   private def createStream = cdmTableStream
-    .snapshotPrefixes(versionedDataGraphBuilderSettings.lookBackInterval)
+    .snapshotPrefixes(versionedDataGraphBuilderSettings.lookBackInterval, versionedDataGraphBuilderSettings.changeCaptureInterval)
     .mapZIOPar(parallelismSettings.parallelism)(blob => cdmTableStream.getStream(blob))
     .flatMap(reader => cdmTableStream.getData(reader))
 

--- a/src/main/scala/services/streaming/processors/ArchivationProcessor.scala
+++ b/src/main/scala/services/streaming/processors/ArchivationProcessor.scala
@@ -20,7 +20,8 @@ class ArchivationProcessor(jdbcConsumer: JdbcConsumer[StagedVersionedBatch],
     ZPipeline.mapZIO({
       case ((batch, other), batchNumber) => 
         for _ <- ZIO.log(s"Archiving batch $batchNumber")
-            result <- jdbcConsumer.archiveBatch(batch)
+            _ <- jdbcConsumer.archiveBatch(batch)
+            result <- jdbcConsumer.dropTempTable(batch)
             _ <- jdbcConsumer.optimizeTarget(archiveTableSettings.archiveTableFullName, batchNumber,
                 archiveTableSettings.archiveOptimizeSettings.batchThreshold,
                 archiveTableSettings.archiveOptimizeSettings.fileSizeThreshold)


### PR DESCRIPTION
Part of #12

## Scope

Implemented:
- Fix the incorrect table drop expression
- Fix the fail if CSV line contains `$`
- Optimize getPrefixes function
- The `dropTempTable` method was moved to processor.
- The retries were removed from JDBC calls

Additional changes:
- Add exception message to the `Application failed` errors.

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.
