### PR TITLE
Change blob deletion behavior

### DIFF
--- a/src/main/scala/models/app/streaming/SourceCleanupRequest.scala
+++ b/src/main/scala/models/app/streaming/SourceCleanupRequest.scala
@@ -4,4 +4,4 @@ package models.app.streaming
 import com.sneaksanddata.arcane.framework.services.storage.models.azure.AdlsStoragePath
 
 case class SourceCleanupRequest(prefix: AdlsStoragePath)
-case class SourceCleanupResult(prefix: AdlsStoragePath, success: Boolean)
+case class SourceCleanupResult(blobName: AdlsStoragePath, deleteMarker: AdlsStoragePath)

--- a/src/main/scala/services/data_providers/microsoft_synapse_link/AzureBlobStorageReaderZIO.scala
+++ b/src/main/scala/services/data_providers/microsoft_synapse_link/AzureBlobStorageReaderZIO.scala
@@ -3,6 +3,7 @@ package services.data_providers.microsoft_synapse_link
 
 import com.azure.core.credential.TokenCredential
 import com.azure.core.http.rest.PagedResponse
+import com.azure.core.util.BinaryData
 import com.azure.identity.DefaultAzureCredentialBuilder
 import com.azure.storage.blob.models.{BlobListDetails, ListBlobsOptions}
 import com.azure.storage.blob.{BlobClient, BlobContainerClient, BlobServiceClientBuilder}
@@ -113,15 +114,15 @@ final class AzureBlobStorageReaderZIO(accountName: String, endpoint: Option[Stri
           case _ => ZStream.empty
     yield eligibleToProcess
     
-  def deleteSourceFile(fileName: AdlsStoragePath): ZIO[Any, Throwable, SourceCleanupResult] =
-    if deleteDryRun then
-      ZIO.log("Dry run: Deleting source file: " + fileName).map(_ => SourceCleanupResult(fileName, true))
-    else
-      ZIO.log("Deleting source file: " + fileName) *>
+  def markForDeletion(fileName: AdlsStoragePath): ZIO[Any, Throwable, SourceCleanupResult] =
+      val deleteMarker = fileName.copy(blobPrefix = fileName.blobPrefix + ".delete")
+      ZIO.log(s"Marking source file for deletion: $fileName with marker: $deleteMarker") *>
         ZIO.attemptBlocking {
-            serviceClient.getBlobContainerClient(fileName.container).getBlobClient(fileName.blobPrefix).deleteIfExists()
+            serviceClient.getBlobContainerClient(fileName.container)
+              .getBlobClient(deleteMarker.blobPrefix)
+              .upload(BinaryData.fromString(""), true)
         }
-        .map(result => SourceCleanupResult(fileName, result))
+        .map(result => SourceCleanupResult(fileName, deleteMarker))
 
 object AzureBlobStorageReaderZIO:
 

--- a/src/main/scala/services/data_providers/microsoft_synapse_link/CdmTableStream.scala
+++ b/src/main/scala/services/data_providers/microsoft_synapse_link/CdmTableStream.scala
@@ -68,7 +68,7 @@ class CdmTableStream(
     else
       for {
         line <- ZIO.attemptBlocking(Option(stream.readLine()))
-        continuation <- tryGetContinuation(stream, quotes + line.getOrElse("").count(_ == '"'), accum.append(s"\n$line"))
+        continuation <- tryGetContinuation(stream, quotes + line.getOrElse("").count(_ == '"'), accum.append(line.map(l => s"\n$l").getOrElse("")))
       }
       yield continuation
 

--- a/src/main/scala/services/streaming/consumers/IcebergSynapseConsumer.scala
+++ b/src/main/scala/services/streaming/consumers/IcebergSynapseConsumer.scala
@@ -54,8 +54,8 @@ class IcebergSynapseConsumer(streamContext: MicrosoftSynapseLinkStreamContext,
 
   private def logResults: ZSink[Any, Throwable, PiplineResult, Any, Unit] = ZSink.foreach {
     case (arch, results) =>
-      ZIO.log(s"Processing completed: ${arch}") *>
-        ZIO.foreach(results)(src => ZIO.log(s"Source cleanup completed for ${src.prefix}: ${src.success}"))
+      ZIO.log(s"Processing completed: $arch") *>
+        ZIO.foreach(results)(src => ZIO.log(s"Marked prefix for deletion: ${src.blobName} with marker ${src.deleteMarker}"))
   }
 
   private def writeStagingTable = ZPipeline[Chunk[DataStreamElement]]()

--- a/src/main/scala/services/streaming/processors/SourceDeleteProcessor.scala
+++ b/src/main/scala/services/streaming/processors/SourceDeleteProcessor.scala
@@ -1,14 +1,10 @@
 package com.sneaksanddata.arcane.microsoft_synapse_link
 package services.streaming.processors
 
-import models.app.{ArchiveTableSettings, ParallelismSettings}
-import services.clients.{BatchArchivationResult, JdbcConsumer}
-import services.streaming.consumers.{CompletedBatch, InFlightBatch, PiplineResult}
+import services.data_providers.microsoft_synapse_link.AzureBlobStorageReaderZIO
+import services.streaming.consumers.{CompletedBatch, PiplineResult}
 
-import com.sneaksanddata.arcane.framework.services.consumers.StagedVersionedBatch
 import com.sneaksanddata.arcane.framework.services.streaming.base.BatchProcessor
-import com.sneaksanddata.arcane.microsoft_synapse_link.models.app.streaming.SourceCleanupRequest
-import com.sneaksanddata.arcane.microsoft_synapse_link.services.data_providers.microsoft_synapse_link.AzureBlobStorageReaderZIO
 import zio.stream.ZPipeline
 import zio.{Task, ZIO, ZLayer}
 
@@ -18,7 +14,7 @@ class SourceDeleteProcessor(azureBlobStorageReaderZIO: AzureBlobStorageReaderZIO
   override def process: ZPipeline[Any, Throwable, CompletedBatch, PiplineResult] =
     ZPipeline.mapZIO({
       case (other, sourceCleanupRequest) => {
-        val results = ZIO.foreach(sourceCleanupRequest)(r => azureBlobStorageReaderZIO.deleteSourceFile(r.prefix))
+        val results = ZIO.foreach(sourceCleanupRequest)(r => azureBlobStorageReaderZIO.markForDeletion(r.prefix))
         results.map(r => (other, r))
       }
     })


### PR DESCRIPTION
Part of #29

## Scope

Implemented:
- This PR changes the delete behavior in the stream plugin: it does not delete the blob objects, only sets the deletion marker

`025-02-06T10.19.35Z/synapsetable/2020.csv` -> `2025-02-06T10.19.35Z/synapsetable/2020.csv.delete`

Additional changes:
- Fixed incorrect blob reading behavior

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.
