### PR TITLE
Change staging table name format

### DIFF
--- a/src/main/scala/services/app/TableManager.scala
+++ b/src/main/scala/services/app/TableManager.scala
@@ -64,7 +64,7 @@ class JdbcTableManager(options: JdbcConsumerOptions,
     yield result
 
   def cleanupStagingTables: Task[Unit] =
-    val sql = s"SHOW TABLES FROM ${streamContext.stagingCatalog} LIKE '${streamContext.stagingTableNamePrefix}_%'"
+    val sql = s"SHOW TABLES FROM ${streamContext.stagingCatalog} LIKE '${streamContext.stagingTableNamePrefix}__%'"
     val statement = ZIO.attemptBlocking {
       sqlConnection.prepareStatement(sql)
     }


### PR DESCRIPTION
Part of #17

## Scope

Implemented:

This PR is part of schema evolution implementation. It changes staging table name format from `{prefix}_{datetime}_{batch_index}` to `{prefix}__{datetime}_{random_uuid}`.

This is required since with schema evolution implemented one data batch can produce more than one staging tables (with different schemas).

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.
