### PR TITLE
Bump lookBack interval maximum to 14 days

### DIFF
--- a/.helm/templates/crd-microsoft-synapse.yaml
+++ b/.helm/templates/crd-microsoft-synapse.yaml
@@ -194,7 +194,7 @@ spec:
                     Number of seconds to look back when determining first set of changes to extract.
                     Can be set in interval from 1 second to 10 hours. Default is 1 hour.
                   minimum: 1
-                  maximum: 604800
+                  maximum: 1209600
                   default: 3600
                 catalogAuthSecretRef:
                   description: |


### PR DESCRIPTION
Part of #12


## Scope

Implemented:
- Increase max lookback interval to 14 days

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.
