### PR TITLE
Fix incorrect datetime filtering for backfills

### DIFF
--- a/src/main/scala/services/data_providers/microsoft_synapse_link/AzureBlobStorageReaderZIO.scala
+++ b/src/main/scala/services/data_providers/microsoft_synapse_link/AzureBlobStorageReaderZIO.scala
@@ -122,7 +122,7 @@ final class AzureBlobStorageReaderZIO(accountName: String, endpoint: Option[Stri
         prefixes <- ZStream.fromIterableZIO(listZIO)
         zippedWithDate <- prefixes.map(blob => (interpretAsDate(blob), blob))
         eligibleToProcess <- zippedWithDate match
-          case (Some(date), blob) if date.isAfter(startFrom) => ZStream.succeed(blob)
+          case (Some(date), blob) if date.isAfter(startFrom) || date.isEqual(startFrom) => ZStream.succeed(blob)
           case _ => ZStream.empty
     yield eligibleToProcess
 


### PR DESCRIPTION
Do not skip the first folder date.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.
