### PR TITLE
Provide infinite iterator to the getRootDropPrefixes method

### DIFF
--- a/src/main/scala/services/data_providers/microsoft_synapse_link/CdmTableStream.scala
+++ b/src/main/scala/services/data_providers/microsoft_synapse_link/CdmTableStream.scala
@@ -169,8 +169,8 @@ class CdmTableStream(name: String,
 
 object CdmTableStream:
 
-  def dateTimeProvider(internal: Duration): Iterator[OffsetDateTime] =
-    Iterator.iterate(OffsetDateTime.now(ZoneOffset.UTC))(_.plus(internal))
+  def dateTimeProvider(interval: Duration): Iterator[OffsetDateTime] =
+    Iterator.iterate(OffsetDateTime.now(ZoneOffset.UTC).minus(interval))(_.plus(interval))
 
   extension (stream: ZStream[Any, Throwable, StoredBlob]) def withSchema(schemaProvider: SchemaProvider[ArcaneSchema]): SchemaEnrichedBlobStream =
     stream.map(blob => SchemaEnrichedBlob(blob, schemaProvider))

--- a/src/main/scala/services/data_providers/microsoft_synapse_link/CdmTableStream.scala
+++ b/src/main/scala/services/data_providers/microsoft_synapse_link/CdmTableStream.scala
@@ -15,6 +15,7 @@ import com.sneaksanddata.arcane.framework.services.storage.models.azure.{AdlsSto
 import com.sneaksanddata.arcane.framework.services.storage.models.base.StoredBlob
 import com.sneaksanddata.arcane.microsoft_synapse_link.services.app.{FieldsFilteringService, TableManager}
 import com.sneaksanddata.arcane.framework.services.streaming.base.BackfillDataProvider
+import microsoft.sql.DateTimeOffset
 import zio.stream.ZStream
 import zio.{Schedule, Task, ZIO, ZLayer}
 
@@ -81,7 +82,9 @@ class CdmTableStream(name: String,
 
 
 
-    val repeatStream = ZStream.fromZIO(dropLast(getRootDropPrefixes(storagePath, None)))
+    val iterator = CdmTableStream.dateTimeProvider(changeCaptureInterval)
+    
+    val repeatStream = ZStream.fromZIO(dropLast(getRootDropPrefixes(storagePath, iterator)))
       .flatMap(x => ZStream.fromIterable(x))
       .flatMap(seb => zioReader.streamPrefixes(storagePath + seb.blob.name).withSchema(seb.schemaProvider))
       .filter(seb => seb.blob.name.endsWith(s"/$name/"))
@@ -104,8 +107,10 @@ class CdmTableStream(name: String,
       case None => tableManager
         .getLastUpdateTime(targetTableSettings.targetTableFullName)
         .map(lastUpdate => zioReader.getRootPrefixes(storagePath,lastUpdate))
-
     getPrefixesTask.map(stream => enrichWithSchema(stream))
+    
+  private def getRootDropPrefixes(storageRoot: AdlsStoragePath, iterator: Iterator[OffsetDateTime]): Task[SchemaEnrichedBlobStream] =
+    ZIO.attempt(zioReader.getRootPrefixes(storagePath, iterator.next())).map(stream => enrichWithSchema(stream))
 
   private def enrichWithSchema(stream: ZStream[Any, Throwable, StoredBlob]): ZStream[Any, Throwable, SchemaEnrichedBlob] =
     stream.filterZIO(prefix => zioReader.blobExists(storagePath + prefix.name + "model.json")).map(prefix => {
@@ -163,6 +168,9 @@ class CdmTableStream(name: String,
         })
 
 object CdmTableStream:
+  
+  def dateTimeProvider(changeCaptureInterval: Duration): Iterator[OffsetDateTime] =
+    Iterator.iterate(OffsetDateTime.now(ZoneOffset.UTC))(_.plus(changeCaptureInterval))
 
   extension (stream: ZStream[Any, Throwable, StoredBlob]) def withSchema(schemaProvider: SchemaProvider[ArcaneSchema]): SchemaEnrichedBlobStream =
     stream.map(blob => SchemaEnrichedBlob(blob, schemaProvider))


### PR DESCRIPTION
Fixes #72

## Scope

Implemented:
- Added overlapping interval iterator

New behavior: 
```
2025-02-20 10:51:21,812 [ZScheduler-Worker-7] INFO   c.s.a.f.logging.ZIOLogAnnotations - Applying batch 0
2025-02-20 10:52:19,984 [ZScheduler-Worker-2] INFO   c.s.a.f.logging.ZIOLogAnnotations - Getting root prefixes stating from 2025-02-20T09:52:19.739121Z
2025-02-20 10:53:20,020 [ZScheduler-Worker-8] INFO   c.s.a.f.logging.ZIOLogAnnotations - Getting root prefixes stating from 2025-02-20T09:53:19.739121Z
2025-02-20 10:54:20,063 [ZScheduler-Worker-7] INFO   c.s.a.f.logging.ZIOLogAnnotations - Getting root prefixes stating from 2025-02-20T09:54:19.739121Z
<<REDACTED>>
2025-02-20 10:55:20,116 [ZScheduler-Worker-12] INFO   c.s.a.f.logging.ZIOLogAnnotations - Getting root prefixes stating from 2025-02-20T09:55:19.739121Z
2025-02-20 10:56:20,162 [ZScheduler-Worker-6] INFO   c.s.a.f.logging.ZIOLogAnnotations - Getting root prefixes stating from 2025-02-20T09:56:19.739121Z
2025-02-20 10:57:20,228 [ZScheduler-Worker-11] INFO   c.s.a.f.logging.ZIOLogAnnotations - Getting root prefixes stating from 2025-02-20T09:57:19.739121Z
```

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.
