### PR TITLE
Filtering-out empty batches after staging processor

### DIFF
--- a/src/main/scala/services/streaming/consumers/IcebergSynapseConsumer.scala
+++ b/src/main/scala/services/streaming/consumers/IcebergSynapseConsumer.scala
@@ -35,7 +35,7 @@ class IcebergSynapseConsumer(stagingProcessor: StagingProcessor,
    * @return ZSink (stream sink for the stream graph).
    */
   override def consume: ZSink[Any, Throwable, IncomingBatch, Any, Unit] =
-    stagingProcessor.process(toInFlightBatch) >>> mergeProcessor.process >>> disposeBatchProcessor.process >>> lifetimeGuard >>> logResults
+    stagingProcessor.process(toInFlightBatch).filter(_.groupedBySchema.nonEmpty)  >>> mergeProcessor.process >>> disposeBatchProcessor.process >>> lifetimeGuard >>> logResults
 
   private def lifetimeGuard: ZPipeline[Any, Throwable, MergeBatchProcessor#BatchType, MergeBatchProcessor#BatchType] =
     ZPipeline.takeUntil(_ => streamLifetimeService.cancelled)


### PR DESCRIPTION
Resolves #96

## Implemented:
- Remove empty batches after the staging processor stage


## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.
