### PR TITLE
Use global variable for the schema cache service

### DIFF
--- a/src/main/scala/main.scala
+++ b/src/main/scala/main.scala
@@ -43,6 +43,8 @@ object main extends ZIOAppDefault {
     } yield AzureBlobStorageReader(connectionOptions.account, connectionOptions.endpoint, credentials)
   }
 
+  private val schemaCache = MutableSchemaCache()
+
   private lazy val streamRunner = streamApplication.provide(
     storageExplorerLayer,
     CdmTableStream.layer,
@@ -66,7 +68,7 @@ object main extends ZIOAppDefault {
     JdbcMergeServiceClient.layer,
     DisposeBatchProcessor.layer,
     SynapseHookManager.layer,
-    MutableSchemaCache.layer)
+    ZLayer.succeed(schemaCache))
 
   @main
   def run: ZIO[Any, Throwable, Unit] =


### PR DESCRIPTION
Construct the schema cache manually

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.
