### PR TITLE
Bump arcane-framework version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ lazy val plugin = (project in file("."))
     name := "arcane-stream-microsoft-synapse-link",
     idePackagePrefix := Some("com.sneaksanddata.arcane.microsoft_synapse_link"),
 
-      libraryDependencies += "com.sneaksanddata" % "arcane-framework_3" % "0.4.2",
+      libraryDependencies += "com.sneaksanddata" % "arcane-framework_3" % "0.4.3",
       libraryDependencies += "io.netty" % "netty-tcnative-boringssl-static" % "2.0.65.Final",
 
     // Test dependencies

--- a/src/main/scala/models/app/MicrosoftSynapseLinkStreamContext.scala
+++ b/src/main/scala/models/app/MicrosoftSynapseLinkStreamContext.scala
@@ -51,7 +51,8 @@ case class MicrosoftSynapseLinkStreamContext(spec: StreamSpec) extends StreamCon
   with StagingDataSettings
   with GraphExecutionSettings:
 
-  override val rowsPerGroup: Int = spec.rowsPerGroup
+  override val rowsPerGroup: Int = System.getenv().getOrDefault("STREAMCONTEXT__ROWS_PER_GROUP", spec.rowsPerGroup.toString).toInt
+  
   override val lookBackInterval: Duration = Duration.ofSeconds(spec.lookBackInterval)
   override val changeCaptureInterval: Duration = Duration.ofSeconds(spec.sourceSettings.changeCaptureIntervalSeconds)
   override val groupingInterval: Duration = Duration.ofSeconds(spec.groupingIntervalSeconds)

--- a/src/main/scala/services/app/StreamRunnerServiceCdm.scala
+++ b/src/main/scala/services/app/StreamRunnerServiceCdm.scala
@@ -38,6 +38,7 @@ private class StreamRunnerServiceCdm(builder: StreamGraphBuilder,
     lifetimeService.start()
     for {
       _ <- zlog("Starting the stream runner")
+      _ <- zlog("Number of rows per group: %s", streamContext.rowsPerGroup.toString)
       _ <- tableManager.cleanupStagingTables(streamContext.stagingCatalogName, streamContext.stagingSchemaName, streamContext.stagingTablePrefix)
       _ <- tableManager.createTargetTable
       _ <- tableManager.createBackFillTable


### PR DESCRIPTION
This PR implementing the following changes:
- Version of Arcane framework was updated.
- Added `STREAMCONTEXT__ROWS_PER_GROUP` environment variable that can be used to override the `rowsPerGroup` StreamContext field.


## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.
