### PR TITLE
Use the real target table for backfill merge operations

### DIFF
--- a/src/main/scala/main.scala
+++ b/src/main/scala/main.scala
@@ -17,12 +17,13 @@ import com.sneaksanddata.arcane.framework.services.cdm.{CdmSchemaProvider, Synap
 import com.sneaksanddata.arcane.framework.services.merging.{JdbcMergeServiceClient, MutableSchemaCache}
 import com.sneaksanddata.arcane.framework.services.storage.services.AzureBlobStorageReader
 import com.sneaksanddata.arcane.framework.services.streaming.processors.transformers.StagingProcessor
-import com.sneaksanddata.arcane.microsoft_synapse_link.services.data_providers.microsoft_synapse_link.{CdmTableStream, MicrosoftSynapseLinkBackfillDataProvider, MicrosoftSynapseLinkBackfillMergeDataProvider, MicrosoftSynapseLinkBackfillOverwriteDataProvider}
+import com.sneaksanddata.arcane.microsoft_synapse_link.services.data_providers.microsoft_synapse_link.{CdmTableStream, MicrosoftSynapseLinkBackfillMergeDataProvider, MicrosoftSynapseLinkBackfillOverwriteDataProvider}
 import zio.*
 import zio.logging.backend.SLF4J
 import com.sneaksanddata.arcane.framework.services.filters.FieldsFilteringService as FrameworkFieldsFilteringService
 import com.sneaksanddata.arcane.framework.services.lakehouse.IcebergS3CatalogWriter
 import com.sneaksanddata.arcane.framework.services.streaming.processors.batch_processors.streaming.{DisposeBatchProcessor, MergeBatchProcessor}
+import com.sneaksanddata.arcane.microsoft_synapse_link.services.data_providers.microsoft_synapse_link.base.MicrosoftSynapseLinkBackfillDataProvider
 
 
 object main extends ZIOAppDefault {

--- a/src/main/scala/main.scala
+++ b/src/main/scala/main.scala
@@ -17,7 +17,7 @@ import com.sneaksanddata.arcane.framework.services.cdm.{CdmSchemaProvider, Synap
 import com.sneaksanddata.arcane.framework.services.merging.{JdbcMergeServiceClient, MutableSchemaCache}
 import com.sneaksanddata.arcane.framework.services.storage.services.AzureBlobStorageReader
 import com.sneaksanddata.arcane.framework.services.streaming.processors.transformers.StagingProcessor
-import com.sneaksanddata.arcane.microsoft_synapse_link.services.data_providers.microsoft_synapse_link.{CdmTableStream, MicrosoftSynapseLinkDataProviderImpl}
+import com.sneaksanddata.arcane.microsoft_synapse_link.services.data_providers.microsoft_synapse_link.{CdmTableStream, MicrosoftSynapseLinkBackfillDataProvider, MicrosoftSynapseLinkBackfillMergeDataProvider, MicrosoftSynapseLinkBackfillOverwriteDataProvider}
 import zio.*
 import zio.logging.backend.SLF4J
 import com.sneaksanddata.arcane.framework.services.filters.FieldsFilteringService as FrameworkFieldsFilteringService
@@ -59,7 +59,7 @@ object main extends ZIOAppDefault {
     TypeAlignmentService.layer,
     BackfillDataGraphBuilder.layer,
     VersionedDataGraphBuilder.layer,
-    MicrosoftSynapseLinkDataProviderImpl.layer,
+    MicrosoftSynapseLinkBackfillDataProvider.compositeLayer,
     IcebergSynapseBackfillConsumer.layer,
     FieldFilteringProcessor.layer,
     FieldsFilteringService.layer,

--- a/src/main/scala/services/data_providers/microsoft_synapse_link/MicrosoftSynapseLinkBackfillDataProvider.scala
+++ b/src/main/scala/services/data_providers/microsoft_synapse_link/MicrosoftSynapseLinkBackfillDataProvider.scala
@@ -1,0 +1,42 @@
+package com.sneaksanddata.arcane.microsoft_synapse_link
+package services.data_providers.microsoft_synapse_link
+
+import com.sneaksanddata.arcane.framework.models.settings.{BackfillBehavior, BackfillSettings}
+import com.sneaksanddata.arcane.framework.services.consumers.StagedBackfillOverwriteBatch
+import com.sneaksanddata.arcane.microsoft_synapse_link.models.app.MicrosoftSynapseLinkStreamContext
+import zio.{Task, ZIO, ZLayer}
+
+trait MicrosoftSynapseLinkBackfillDataProvider:
+
+  def requestBackfill: Task[StagedBackfillOverwriteBatch | Unit]
+  
+  
+object MicrosoftSynapseLinkBackfillDataProvider:
+  
+  /**
+   * The environment required for the MicrosoftSynapseLinkBackfillDataProvider.
+   */
+  type Environemnt = MicrosoftSynapseLinkStreamContext
+    & MicrosoftSynapseLinkBackfillMergeDataProvider
+    & MicrosoftSynapseLinkBackfillOverwriteDataProvider
+
+  /**
+   * The ZLayer for the stream runner service.
+   */
+  val layer: ZLayer[Environemnt, Nothing, MicrosoftSynapseLinkBackfillDataProvider] =
+    ZLayer {
+      for {
+        settings <- ZIO.service[BackfillSettings]
+        backfillDataProvider <- settings.backfillBehavior match
+          case BackfillBehavior.Merge => ZIO.service[MicrosoftSynapseLinkBackfillMergeDataProvider]
+          case BackfillBehavior.Overwrite => ZIO.service[MicrosoftSynapseLinkBackfillOverwriteDataProvider]
+      } yield backfillDataProvider
+    }
+
+
+  type CompositeEnvironment = MicrosoftSynapseLinkStreamContext
+    & MicrosoftSynapseLinkBackfillMergeDataProvider.Environment
+    & MicrosoftSynapseLinkBackfillOverwriteDataProvider.Environment
+
+  val compositeLayer: ZLayer[CompositeEnvironment, Nothing, MicrosoftSynapseLinkBackfillDataProvider] =
+    MicrosoftSynapseLinkBackfillOverwriteDataProvider.layer >+> MicrosoftSynapseLinkBackfillMergeDataProvider.layer >>> layer

--- a/src/main/scala/services/data_providers/microsoft_synapse_link/MicrosoftSynapseLinkBackfillMergeDataProvider.scala
+++ b/src/main/scala/services/data_providers/microsoft_synapse_link/MicrosoftSynapseLinkBackfillMergeDataProvider.scala
@@ -15,6 +15,7 @@ import com.sneaksanddata.arcane.framework.services.merging.JdbcMergeServiceClien
 import com.sneaksanddata.arcane.framework.services.streaming.base.HookManager
 import com.sneaksanddata.arcane.framework.services.streaming.processors.batch_processors.streaming.{DisposeBatchProcessor, MergeBatchProcessor}
 import com.sneaksanddata.arcane.framework.services.streaming.processors.transformers.StagingProcessor
+import com.sneaksanddata.arcane.microsoft_synapse_link.services.data_providers.microsoft_synapse_link.base.{BackfillBatchInFlight, MicrosoftSynapseLinkBackfillDataProvider}
 import org.apache.iceberg.rest.RESTCatalog
 import org.apache.iceberg.{Schema, Table}
 import zio.{Task, ZIO, ZLayer}
@@ -28,7 +29,7 @@ class MicrosoftSynapseLinkBackfillMergeDataProvider(cdmTableStream: CdmTableStre
                                                         mergeProcessor: MergeBatchProcessor,
                                                         hookManager: HookManager) extends MicrosoftSynapseLinkBackfillDataProvider:
 
-  def requestBackfill: Task[StagedBackfillOverwriteBatch|Unit] =
+  def requestBackfill: Task[BackfillBatchInFlight] =
     for
       _ <- backfillSettings.backfillBehavior match
         case BackfillBehavior.Merge => ZIO.unit

--- a/src/main/scala/services/data_providers/microsoft_synapse_link/MicrosoftSynapseLinkBackfillMergeDataProvider.scala
+++ b/src/main/scala/services/data_providers/microsoft_synapse_link/MicrosoftSynapseLinkBackfillMergeDataProvider.scala
@@ -1,0 +1,104 @@
+package com.sneaksanddata.arcane.microsoft_synapse_link
+package services.data_providers.microsoft_synapse_link
+
+import models.app.*
+import services.streaming.consumers.DataStreamElementExtensions.given_MetadataEnrichedRowStreamElement_DataStreamElement
+import services.streaming.consumers.IndexedStagedBatchesImpl
+import services.streaming.processors.{CdmGroupingProcessor, FieldFilteringProcessor}
+
+import com.sneaksanddata.arcane.framework.logging.ZIOLogAnnotations.zlog
+import com.sneaksanddata.arcane.framework.models.settings.*
+import com.sneaksanddata.arcane.framework.services.base.TableManager
+import com.sneaksanddata.arcane.framework.services.consumers.*
+import com.sneaksanddata.arcane.framework.services.lakehouse.base.{CatalogWriter, CatalogWriterBuilder, IcebergCatalogSettings}
+import com.sneaksanddata.arcane.framework.services.merging.JdbcMergeServiceClient
+import com.sneaksanddata.arcane.framework.services.streaming.base.HookManager
+import com.sneaksanddata.arcane.framework.services.streaming.processors.batch_processors.streaming.{DisposeBatchProcessor, MergeBatchProcessor}
+import com.sneaksanddata.arcane.framework.services.streaming.processors.transformers.StagingProcessor
+import org.apache.iceberg.rest.RESTCatalog
+import org.apache.iceberg.{Schema, Table}
+import zio.{Task, ZIO, ZLayer}
+
+class MicrosoftSynapseLinkBackfillMergeDataProvider(cdmTableStream: CdmTableStream,
+                                                        groupingProcessor: CdmGroupingProcessor,
+                                                        fieldFilteringProcessor: FieldFilteringProcessor,
+                                                        backfillSettings: BackfillSettings,
+                                                        disposeBatchProcessor: DisposeBatchProcessor,
+                                                        stagingProcessor: StagingProcessor,
+                                                        mergeProcessor: MergeBatchProcessor,
+                                                        hookManager: HookManager) extends MicrosoftSynapseLinkBackfillDataProvider:
+
+  def requestBackfill: Task[StagedBackfillOverwriteBatch|Unit] =
+    for
+      _ <- backfillSettings.backfillBehavior match
+        case BackfillBehavior.Merge => ZIO.unit
+        case BackfillBehavior.Overwrite => ZIO.die(new IllegalArgumentException("Running backfill overwrite in overwrite runner"))
+      _ <- zlog(s"Starting backfill process. Backfill behavior: ${backfillSettings.backfillBehavior}")
+      cleanupRequests <- backfillStream.runDrain
+      _ <- zlog("Backfill process completed")
+    yield ()
+
+  private def backfillStream =
+    cdmTableStream.getPrefixesFromDate(backfillSettings.backfillStartDate.getOrElse(throw new IllegalArgumentException("Backfill start date is not set")))
+      .mapZIO(blob => cdmTableStream.getStream(blob))
+      .flatMap(reader => cdmTableStream.getData(reader))
+      .via(fieldFilteringProcessor.process)
+      .via(groupingProcessor.process)
+      .via(stagingProcessor.process(toInFlightBatch, hookManager.onBatchStaged))
+      .via(mergeProcessor.process)
+      .via(disposeBatchProcessor.process)
+
+  def toInFlightBatch(batches: Iterable[StagedVersionedBatch & MergeableBatch], index: Long, others: Any): MergeBatchProcessor#BatchType =
+    new IndexedStagedBatchesImpl(batches, index)
+
+object MicrosoftSynapseLinkBackfillMergeDataProvider:
+
+  type Environment = CdmTableStream
+    & CdmGroupingProcessor
+    & FieldFilteringProcessor
+    & BackfillSettings
+    & DisposeBatchProcessor
+    & HookManager
+    & MergeBatchProcessor
+    & StagingProcessor
+
+  def apply(cdmTableStream: CdmTableStream,
+            groupingProcessor: CdmGroupingProcessor,
+            fieldFilteringProcessor: FieldFilteringProcessor,
+            backfillSettings: BackfillSettings,
+            disposeBatchProcessor: DisposeBatchProcessor,
+            stagingProcessor: StagingProcessor,
+            mergeProcessor: MergeBatchProcessor,
+            hookManager: HookManager): MicrosoftSynapseLinkBackfillMergeDataProvider =
+    new MicrosoftSynapseLinkBackfillMergeDataProvider(
+      cdmTableStream,
+      groupingProcessor,
+      fieldFilteringProcessor,
+      backfillSettings,
+      disposeBatchProcessor,
+      stagingProcessor,
+      mergeProcessor,
+      hookManager)
+
+  def layer: ZLayer[Environment, Nothing, MicrosoftSynapseLinkBackfillMergeDataProvider] =
+    ZLayer {
+      for
+        cdmTableStream <- ZIO.service[CdmTableStream]
+        groupingProcessor <- ZIO.service[CdmGroupingProcessor]
+        fieldFilteringProcessor <- ZIO.service[FieldFilteringProcessor]
+        backfillSettings <- ZIO.service[BackfillSettings]
+        disposeBatchProcessor <- ZIO.service[DisposeBatchProcessor]
+        stagingProcessor <- ZIO.service[StagingProcessor]
+        mergeProcessor <- ZIO.service[MergeBatchProcessor]
+        hookManager <- ZIO.service[HookManager]
+      yield MicrosoftSynapseLinkBackfillMergeDataProvider(
+        cdmTableStream,
+        groupingProcessor,
+        fieldFilteringProcessor,
+        backfillSettings,
+        disposeBatchProcessor,
+        stagingProcessor,
+        mergeProcessor,
+        hookManager)
+    }
+

--- a/src/main/scala/services/data_providers/microsoft_synapse_link/MicrosoftSynapseLinkBackfillOverwriteDataProvider.scala
+++ b/src/main/scala/services/data_providers/microsoft_synapse_link/MicrosoftSynapseLinkBackfillOverwriteDataProvider.scala
@@ -15,6 +15,7 @@ import com.sneaksanddata.arcane.framework.services.merging.JdbcMergeServiceClien
 import com.sneaksanddata.arcane.framework.services.streaming.base.HookManager
 import com.sneaksanddata.arcane.framework.services.streaming.processors.batch_processors.streaming.{DisposeBatchProcessor, MergeBatchProcessor}
 import com.sneaksanddata.arcane.framework.services.streaming.processors.transformers.StagingProcessor
+import com.sneaksanddata.arcane.microsoft_synapse_link.services.data_providers.microsoft_synapse_link.base.MicrosoftSynapseLinkBackfillDataProvider
 import org.apache.iceberg.rest.RESTCatalog
 import org.apache.iceberg.{Schema, Table}
 import zio.{Task, ZIO, ZLayer}

--- a/src/main/scala/services/data_providers/microsoft_synapse_link/MicrosoftSynapseLinkBackfillOverwriteDataProvider.scala
+++ b/src/main/scala/services/data_providers/microsoft_synapse_link/MicrosoftSynapseLinkBackfillOverwriteDataProvider.scala
@@ -19,11 +19,6 @@ import org.apache.iceberg.rest.RESTCatalog
 import org.apache.iceberg.{Schema, Table}
 import zio.{Task, ZIO, ZLayer}
 
-type BackfillBatchInFlight = StagedBackfillBatch
-
-trait MicrosoftSynapseLinkDataProvider:
-
-  def requestBackfill: Task[BackfillBatchInFlight]
 
 case class BackfillTempTableSettings(override val targetTableFullName: String) extends TargetTableSettings:
   override val maintenanceSettings: TableMaintenanceSettings = new TableMaintenanceSettings {
@@ -33,22 +28,22 @@ case class BackfillTempTableSettings(override val targetTableFullName: String) e
   }
 
 
-class MicrosoftSynapseLinkDataProviderImpl(cdmTableStream: CdmTableStream,
-                                           streamContext: MicrosoftSynapseLinkStreamContext,
-                                           parallelismSettings: ParallelismSettings,
-                                           groupingProcessor: CdmGroupingProcessor,
-                                           tableManager: TableManager,
-                                           sinkSettings: TargetTableSettings,
-                                           fieldFilteringProcessor: FieldFilteringProcessor,
-                                           backfillSettings: BackfillSettings,
-                                           jdbcMergeServiceClient: JdbcMergeServiceClient,
-                                           tablePropertiesSettings: TablePropertiesSettings,
-                                           stagingDataSettings: StagingDataSettings,
-                                           targetTableSettings: TargetTableSettings,
-                                           icebergCatalogSettings: IcebergCatalogSettings,
-                                           catalogWriter: CatalogWriter[RESTCatalog, Table, Schema],
-                                           disposeBatchProcessor: DisposeBatchProcessor,
-                                           hookManager: HookManager) extends MicrosoftSynapseLinkDataProvider:
+class MicrosoftSynapseLinkBackfillOverwriteDataProvider(cdmTableStream: CdmTableStream,
+                                                        streamContext: MicrosoftSynapseLinkStreamContext,
+                                                        parallelismSettings: ParallelismSettings,
+                                                        groupingProcessor: CdmGroupingProcessor,
+                                                        tableManager: TableManager,
+                                                        sinkSettings: TargetTableSettings,
+                                                        fieldFilteringProcessor: FieldFilteringProcessor,
+                                                        backfillSettings: BackfillSettings,
+                                                        jdbcMergeServiceClient: JdbcMergeServiceClient,
+                                                        tablePropertiesSettings: TablePropertiesSettings,
+                                                        stagingDataSettings: StagingDataSettings,
+                                                        targetTableSettings: TargetTableSettings,
+                                                        icebergCatalogSettings: IcebergCatalogSettings,
+                                                        catalogWriter: CatalogWriter[RESTCatalog, Table, Schema],
+                                                        disposeBatchProcessor: DisposeBatchProcessor,
+                                                        hookManager: HookManager) extends MicrosoftSynapseLinkBackfillDataProvider:
 
   private val backFillTableName = streamContext.backfillTableFullName
   private val tempTargetTableSettings = BackfillTempTableSettings(backFillTableName)
@@ -56,9 +51,11 @@ class MicrosoftSynapseLinkDataProviderImpl(cdmTableStream: CdmTableStream,
   
   private val stagingProcessor = StagingProcessor(stagingDataSettings, tablePropertiesSettings, tempTargetTableSettings, icebergCatalogSettings, catalogWriter)
 
-  def requestBackfill: Task[BackfillBatchInFlight] =
-
+  def requestBackfill: Task[StagedBackfillOverwriteBatch] =
     for
+      _ <- backfillSettings.backfillBehavior match
+        case BackfillBehavior.Merge => ZIO.die(new IllegalArgumentException("Running backfill merge in overwrite runner"))
+        case BackfillBehavior.Overwrite => ZIO.unit
       _ <- zlog(s"Starting backfill process. Backfill behavior: ${backfillSettings.backfillBehavior}")
       cleanupRequests <- backfillStream.runDrain
       _ <- zlog("Backfill process completed")
@@ -78,19 +75,14 @@ class MicrosoftSynapseLinkDataProviderImpl(cdmTableStream: CdmTableStream,
   def toInFlightBatch(batches: Iterable[StagedVersionedBatch & MergeableBatch], index: Long, others: Any): MergeBatchProcessor#BatchType =
     new IndexedStagedBatchesImpl(batches, index)
 
-  private def createBackfillBatch(tableName: String): Task[StagedBackfillBatch] =
+  private def createBackfillBatch(tableName: String): Task[StagedBackfillOverwriteBatch] =
     for schema <- jdbcMergeServiceClient.getSchema(tableName)
-    yield backfillSettings.backfillBehavior match
-      case BackfillBehavior.Overwrite => SynapseLinkBackfillOverwriteBatch(tableName,
-        schema,
-        sinkSettings.targetTableFullName,
-        tablePropertiesSettings)
-      case BackfillBehavior.Merge => SynapseLinkBackfillMergeBatch(tableName,
+    yield SynapseLinkBackfillOverwriteBatch(tableName,
         schema,
         sinkSettings.targetTableFullName,
         tablePropertiesSettings)
 
-object MicrosoftSynapseLinkDataProviderImpl:
+object MicrosoftSynapseLinkBackfillOverwriteDataProvider:
 
   type Environment = CdmTableStream
     & MicrosoftSynapseLinkStreamContext
@@ -125,8 +117,8 @@ object MicrosoftSynapseLinkDataProviderImpl:
             icebergCatalogSettings: IcebergCatalogSettings,
             catalogWriter: CatalogWriter[RESTCatalog, Table, Schema],
             disposeBatchProcessor: DisposeBatchProcessor,
-            hookManager: HookManager): MicrosoftSynapseLinkDataProviderImpl =
-    new MicrosoftSynapseLinkDataProviderImpl(
+            hookManager: HookManager): MicrosoftSynapseLinkBackfillOverwriteDataProvider =
+    new MicrosoftSynapseLinkBackfillOverwriteDataProvider(
       cdmTableStream,
       streamContext,
       parallelismSettings,
@@ -144,7 +136,7 @@ object MicrosoftSynapseLinkDataProviderImpl:
       disposeBatchProcessor,
       hookManager)
 
-  def layer: ZLayer[Environment, Nothing, MicrosoftSynapseLinkDataProvider] =
+  def layer: ZLayer[Environment, Nothing, MicrosoftSynapseLinkBackfillOverwriteDataProvider] =
     ZLayer {
       for
         cdmTableStream <- ZIO.service[CdmTableStream]
@@ -164,7 +156,7 @@ object MicrosoftSynapseLinkDataProviderImpl:
         icebergCatalogSettings <- ZIO.service[IcebergCatalogSettings]
         catalogWriter<- ZIO.service[CatalogWriter[RESTCatalog, Table, Schema]]
         hookManager <- ZIO.service[HookManager]
-      yield MicrosoftSynapseLinkDataProviderImpl(cdmTableStream,
+      yield MicrosoftSynapseLinkBackfillOverwriteDataProvider(cdmTableStream,
         streamContext,
         parallelismSettings,
         groupingProcessor,

--- a/src/main/scala/services/data_providers/microsoft_synapse_link/base/MicrosoftSynapseLinkBackfillDataProvider.scala
+++ b/src/main/scala/services/data_providers/microsoft_synapse_link/base/MicrosoftSynapseLinkBackfillDataProvider.scala
@@ -1,14 +1,21 @@
 package com.sneaksanddata.arcane.microsoft_synapse_link
-package services.data_providers.microsoft_synapse_link
+package services.data_providers.microsoft_synapse_link.base
+
+import models.app.MicrosoftSynapseLinkStreamContext
+import services.data_providers.microsoft_synapse_link.{MicrosoftSynapseLinkBackfillMergeDataProvider, MicrosoftSynapseLinkBackfillOverwriteDataProvider}
 
 import com.sneaksanddata.arcane.framework.models.settings.{BackfillBehavior, BackfillSettings}
 import com.sneaksanddata.arcane.framework.services.consumers.StagedBackfillOverwriteBatch
-import com.sneaksanddata.arcane.microsoft_synapse_link.models.app.MicrosoftSynapseLinkStreamContext
 import zio.{Task, ZIO, ZLayer}
 
+type BackfillBatchInFlight = StagedBackfillOverwriteBatch | Unit
+
+/**
+ * Provides the backfill batch if the stream is running in the backfill mode.
+ */
 trait MicrosoftSynapseLinkBackfillDataProvider:
 
-  def requestBackfill: Task[StagedBackfillOverwriteBatch | Unit]
+  def requestBackfill: Task[BackfillBatchInFlight]
   
   
 object MicrosoftSynapseLinkBackfillDataProvider:

--- a/src/main/scala/services/graph_builder/BackfillDataGraphBuilder.scala
+++ b/src/main/scala/services/graph_builder/BackfillDataGraphBuilder.scala
@@ -1,13 +1,14 @@
 package com.sneaksanddata.arcane.microsoft_synapse_link
 package services.graph_builder
 
-import services.data_providers.microsoft_synapse_link.{DataStreamElement, MicrosoftSynapseLinkBackfillDataProvider}
+import services.data_providers.microsoft_synapse_link.DataStreamElement
 import services.streaming.consumers.IcebergSynapseBackfillConsumer
 
 import com.sneaksanddata.arcane.framework.logging.ZIOLogAnnotations.*
 import com.sneaksanddata.arcane.framework.services.app.base.StreamLifetimeService
 import com.sneaksanddata.arcane.framework.services.consumers.StagedBackfillOverwriteBatch
 import com.sneaksanddata.arcane.framework.services.streaming.base.{BatchProcessor, StreamGraphBuilder}
+import com.sneaksanddata.arcane.microsoft_synapse_link.services.data_providers.microsoft_synapse_link.base.MicrosoftSynapseLinkBackfillDataProvider
 import zio.stream.{ZSink, ZStream}
 import zio.{Chunk, ZIO, ZLayer}
 

--- a/src/main/scala/services/graph_builder/BackfillDataGraphBuilder.scala
+++ b/src/main/scala/services/graph_builder/BackfillDataGraphBuilder.scala
@@ -1,23 +1,24 @@
 package com.sneaksanddata.arcane.microsoft_synapse_link
 package services.graph_builder
 
-import services.data_providers.microsoft_synapse_link.{BackfillBatchInFlight, DataStreamElement, MicrosoftSynapseLinkDataProvider}
+import services.data_providers.microsoft_synapse_link.{DataStreamElement, MicrosoftSynapseLinkBackfillDataProvider}
 import services.streaming.consumers.IcebergSynapseBackfillConsumer
 
 import com.sneaksanddata.arcane.framework.logging.ZIOLogAnnotations.*
 import com.sneaksanddata.arcane.framework.services.app.base.StreamLifetimeService
+import com.sneaksanddata.arcane.framework.services.consumers.StagedBackfillOverwriteBatch
 import com.sneaksanddata.arcane.framework.services.streaming.base.{BatchProcessor, StreamGraphBuilder}
 import zio.stream.{ZSink, ZStream}
 import zio.{Chunk, ZIO, ZLayer}
 
-class BackfillDataGraphBuilder(backfillDataProvider: MicrosoftSynapseLinkDataProvider,
+class BackfillDataGraphBuilder(backfillDataProvider: MicrosoftSynapseLinkBackfillDataProvider,
                                streamLifetimeService: StreamLifetimeService,
                                batchProcessor: BatchProcessor[DataStreamElement, Chunk[DataStreamElement]],
                                batchConsumer: IcebergSynapseBackfillConsumer)
   extends StreamGraphBuilder:
 
 
-  override type StreamElementType = BackfillBatchInFlight
+  override type StreamElementType = StagedBackfillOverwriteBatch|Unit
 
   override def create: ZStream[Any, Throwable, StreamElementType] = ZStream.fromZIO(backfillDataProvider.requestBackfill)
 
@@ -27,7 +28,7 @@ class BackfillDataGraphBuilder(backfillDataProvider: MicrosoftSynapseLinkDataPro
  * The companion object for the VersionedDataGraphBuilder class.
  */
 object BackfillDataGraphBuilder:
-  type Environment = MicrosoftSynapseLinkDataProvider
+  type Environment = MicrosoftSynapseLinkBackfillDataProvider
     & StreamLifetimeService
     & BatchProcessor[DataStreamElement, Chunk[DataStreamElement]]
     & IcebergSynapseBackfillConsumer
@@ -40,7 +41,7 @@ object BackfillDataGraphBuilder:
    * @param batchProcessor        The batch processor.
    * @return A new instance of the BackfillDataGraphBuilder class.
    */
-  def apply(backfillDataProvider: MicrosoftSynapseLinkDataProvider,
+  def apply(backfillDataProvider: MicrosoftSynapseLinkBackfillDataProvider,
             streamLifetimeService: StreamLifetimeService,
             batchProcessor: BatchProcessor[DataStreamElement, Chunk[DataStreamElement]],
             batchConsumer: IcebergSynapseBackfillConsumer): BackfillDataGraphBuilder =
@@ -55,7 +56,7 @@ object BackfillDataGraphBuilder:
   ZLayer {
     for
       _ <- zlog("Running in backfill mode")
-      dp <- ZIO.service[MicrosoftSynapseLinkDataProvider]
+      dp <- ZIO.service[MicrosoftSynapseLinkBackfillDataProvider]
       ls <- ZIO.service[StreamLifetimeService]
       bp <- ZIO.service[BatchProcessor[DataStreamElement, Chunk[DataStreamElement]]]
       bc <- ZIO.service[IcebergSynapseBackfillConsumer]

--- a/src/main/scala/services/graph_builder/VersionedDataGraphBuilder.scala
+++ b/src/main/scala/services/graph_builder/VersionedDataGraphBuilder.scala
@@ -104,7 +104,6 @@ object VersionedDataGraphBuilder:
   def layer: ZLayer[Environment, Nothing, VersionedDataGraphBuilder] =
     ZLayer {
       for
-        _ <- zlog("Running in streaming mode")
         sss <- ZIO.service[VersionedDataGraphBuilderSettings]
         dp <- ZIO.service[CdmTableStream]
         ls <- ZIO.service[StreamLifetimeService]

--- a/src/main/scala/services/streaming/consumers/IcebergSynapseBackfillConsumer.scala
+++ b/src/main/scala/services/streaming/consumers/IcebergSynapseBackfillConsumer.scala
@@ -7,6 +7,7 @@ import com.sneaksanddata.arcane.framework.services.base.{DisposeServiceClient, M
 import com.sneaksanddata.arcane.framework.services.consumers.StagedBackfillOverwriteBatch
 import com.sneaksanddata.arcane.framework.services.storage.services.AzureBlobStorageReader
 import com.sneaksanddata.arcane.framework.services.streaming.base.BatchConsumer
+import com.sneaksanddata.arcane.microsoft_synapse_link.services.data_providers.microsoft_synapse_link.base.BackfillBatchInFlight
 import zio.stream.ZSink
 import zio.{Schedule, Task, ZIO, ZLayer}
 
@@ -18,18 +19,18 @@ class IcebergSynapseBackfillConsumer(mergeServiceClient: MergeServiceClient,
                                      reader: AzureBlobStorageReader,
                                      targetTableSettings: TargetTableSettings,
                                      tableManager: TableManager)
-  extends BatchConsumer[StagedBackfillOverwriteBatch|Unit]:
+  extends BatchConsumer[BackfillBatchInFlight]:
 
   /**
    * Returns the sink that consumes the batch.
    *
    * @return ZSink (stream sink for the stream graph).
    */
-  override def consume: ZSink[Any, Throwable, StagedBackfillOverwriteBatch|Unit, Any, Unit] =
+  override def consume: ZSink[Any, Throwable, BackfillBatchInFlight, Any, Unit] =
     ZSink.foreach(batch => consumeBackfillBatch(batch))
 
 
-  private def consumeBackfillBatch(batch: StagedBackfillOverwriteBatch|Unit): Task[Unit] =
+  private def consumeBackfillBatch(batch: BackfillBatchInFlight): Task[Unit] =
     for
       _ <- zlog(s"Consuming backfill batch $batch")
       _ <- batch match


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/arcane-framework-scala/issues/100

This PR fixes the Backfill behavior in Synapse link stream. The same changes we need to do in arcane-framework repo and this PR is only a hotfix.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.
