### PR TITLE
Bump framework to 1.0.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ lazy val plugin = (project in file("."))
     name := "arcane-stream-microsoft-synapse-link",
     idePackagePrefix := Some("com.sneaksanddata.arcane.microsoft_synapse_link"),
 
-    libraryDependencies += "com.sneaksanddata" % "arcane-framework_3" % "0.9.7",
+    libraryDependencies += "com.sneaksanddata" % "arcane-framework_3" % "1.0.1",
     libraryDependencies += "io.netty" % "netty-tcnative-boringssl-static" % "2.0.65.Final",
 
     // bugfix for upgrade header

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -68,7 +68,7 @@ services:
 ##    volumes:
 ##      - ./http-proxy-envoy-config.yaml:/etc/envoy/envoy.yaml
   lakekeeper:
-    image: quay.io/lakekeeper/catalog:latest-main
+    image: quay.io/lakekeeper/catalog:v0.8.5
     network_mode: host
     environment:
 #      - LAKEKEEPER__PG_ENCRYPTION_KEY=This-is-NOT-Secure!
@@ -93,7 +93,7 @@ services:
       minio:
         condition: service_healthy
   lakekeeper_migrate:
-    image: quay.io/lakekeeper/catalog:latest-main
+    image: quay.io/lakekeeper/catalog:v0.8.5
     network_mode: host
     environment:
 #      - LAKEKEEPER__PG_ENCRYPTION_KEY=This-is-NOT-Secure!

--- a/src/main/scala/main.scala
+++ b/src/main/scala/main.scala
@@ -9,39 +9,22 @@ import com.sneaksanddata.arcane.framework.models.app.StreamContext
 import com.sneaksanddata.arcane.framework.models.settings.{GroupingSettings, VersionedDataGraphBuilderSettings}
 import com.sneaksanddata.arcane.framework.services.app.{GenericStreamRunnerService, PosixStreamLifetimeService}
 import com.sneaksanddata.arcane.framework.services.app.base.{StreamLifetimeService, StreamRunnerService}
+import com.sneaksanddata.arcane.framework.services.caching.schema_cache.MutableSchemaCache
 import com.sneaksanddata.arcane.framework.services.synapse.SynapseHookManager
-import com.sneaksanddata.arcane.framework.services.merging.{JdbcMergeServiceClient, MutableSchemaCache}
-import com.sneaksanddata.arcane.framework.services.storage.services.AzureBlobStorageReader
-import com.sneaksanddata.arcane.framework.services.streaming.processors.transformers.{
-  FieldFilteringTransformer,
-  StagingProcessor
-}
+import com.sneaksanddata.arcane.framework.services.merging.JdbcMergeServiceClient
+import com.sneaksanddata.arcane.framework.services.streaming.processors.transformers.{FieldFilteringTransformer, StagingProcessor}
 import zio.*
 import zio.logging.backend.SLF4J
-import com.sneaksanddata.arcane.framework.services.filters.{
-  FieldsFilteringService,
-  FieldsFilteringService as FrameworkFieldsFilteringService
-}
-import com.sneaksanddata.arcane.framework.services.lakehouse.IcebergS3CatalogWriter
-import com.sneaksanddata.arcane.framework.services.streaming.data_providers.backfill.{
-  GenericBackfillStreamingMergeDataProvider,
-  GenericBackfillStreamingOverwriteDataProvider
-}
-import com.sneaksanddata.arcane.framework.services.streaming.graph_builders.{
-  GenericGraphBuilderFactory,
-  GenericStreamingGraphBuilder
-}
+import com.sneaksanddata.arcane.framework.services.filters.{FieldsFilteringService, FieldsFilteringService as FrameworkFieldsFilteringService}
+import com.sneaksanddata.arcane.framework.services.iceberg.IcebergS3CatalogWriter
+import com.sneaksanddata.arcane.framework.services.storage.services.azure.AzureBlobStorageReader
+import com.sneaksanddata.arcane.framework.services.streaming.data_providers.backfill.{GenericBackfillStreamingMergeDataProvider, GenericBackfillStreamingOverwriteDataProvider}
+import com.sneaksanddata.arcane.framework.services.streaming.graph_builders.{GenericGraphBuilderFactory, GenericStreamingGraphBuilder}
 import com.sneaksanddata.arcane.framework.services.streaming.processors.GenericGroupingTransformer
 import com.sneaksanddata.arcane.framework.services.streaming.processors.batch_processors.backfill.BackfillApplyBatchProcessor
-import com.sneaksanddata.arcane.framework.services.streaming.processors.batch_processors.streaming.{
-  DisposeBatchProcessor,
-  MergeBatchProcessor
-}
+import com.sneaksanddata.arcane.framework.services.streaming.processors.batch_processors.streaming.{DisposeBatchProcessor, MergeBatchProcessor}
 import com.sneaksanddata.arcane.framework.services.synapse.base.{SynapseLinkDataProvider, SynapseLinkReader}
-import com.sneaksanddata.arcane.framework.services.synapse.{
-  SynapseBackfillOverwriteBatchFactory,
-  SynapseLinkStreamingDataProvider
-}
+import com.sneaksanddata.arcane.framework.services.synapse.{SynapseBackfillOverwriteBatchFactory, SynapseLinkStreamingDataProvider}
 
 object main extends ZIOAppDefault {
 

--- a/src/main/scala/main.scala
+++ b/src/main/scala/main.scala
@@ -12,19 +12,37 @@ import com.sneaksanddata.arcane.framework.services.app.base.{StreamLifetimeServi
 import com.sneaksanddata.arcane.framework.services.caching.schema_cache.MutableSchemaCache
 import com.sneaksanddata.arcane.framework.services.synapse.SynapseHookManager
 import com.sneaksanddata.arcane.framework.services.merging.JdbcMergeServiceClient
-import com.sneaksanddata.arcane.framework.services.streaming.processors.transformers.{FieldFilteringTransformer, StagingProcessor}
+import com.sneaksanddata.arcane.framework.services.streaming.processors.transformers.{
+  FieldFilteringTransformer,
+  StagingProcessor
+}
 import zio.*
 import zio.logging.backend.SLF4J
-import com.sneaksanddata.arcane.framework.services.filters.{FieldsFilteringService, FieldsFilteringService as FrameworkFieldsFilteringService}
+import com.sneaksanddata.arcane.framework.services.filters.{
+  FieldsFilteringService,
+  FieldsFilteringService as FrameworkFieldsFilteringService
+}
 import com.sneaksanddata.arcane.framework.services.iceberg.IcebergS3CatalogWriter
 import com.sneaksanddata.arcane.framework.services.storage.services.azure.AzureBlobStorageReader
-import com.sneaksanddata.arcane.framework.services.streaming.data_providers.backfill.{GenericBackfillStreamingMergeDataProvider, GenericBackfillStreamingOverwriteDataProvider}
-import com.sneaksanddata.arcane.framework.services.streaming.graph_builders.{GenericGraphBuilderFactory, GenericStreamingGraphBuilder}
+import com.sneaksanddata.arcane.framework.services.streaming.data_providers.backfill.{
+  GenericBackfillStreamingMergeDataProvider,
+  GenericBackfillStreamingOverwriteDataProvider
+}
+import com.sneaksanddata.arcane.framework.services.streaming.graph_builders.{
+  GenericGraphBuilderFactory,
+  GenericStreamingGraphBuilder
+}
 import com.sneaksanddata.arcane.framework.services.streaming.processors.GenericGroupingTransformer
 import com.sneaksanddata.arcane.framework.services.streaming.processors.batch_processors.backfill.BackfillApplyBatchProcessor
-import com.sneaksanddata.arcane.framework.services.streaming.processors.batch_processors.streaming.{DisposeBatchProcessor, MergeBatchProcessor}
+import com.sneaksanddata.arcane.framework.services.streaming.processors.batch_processors.streaming.{
+  DisposeBatchProcessor,
+  MergeBatchProcessor
+}
 import com.sneaksanddata.arcane.framework.services.synapse.base.{SynapseLinkDataProvider, SynapseLinkReader}
-import com.sneaksanddata.arcane.framework.services.synapse.{SynapseBackfillOverwriteBatchFactory, SynapseLinkStreamingDataProvider}
+import com.sneaksanddata.arcane.framework.services.synapse.{
+  SynapseBackfillOverwriteBatchFactory,
+  SynapseLinkStreamingDataProvider
+}
 
 object main extends ZIOAppDefault {
 

--- a/src/main/scala/models/app/MicrosoftSynapseLinkStreamContext.scala
+++ b/src/main/scala/models/app/MicrosoftSynapseLinkStreamContext.scala
@@ -5,28 +5,9 @@ import models.app.contracts.StreamSpec
 
 import com.sneaksanddata.arcane.framework.models.app.StreamContext
 import com.sneaksanddata.arcane.framework.models.settings
-import com.sneaksanddata.arcane.framework.models.settings.{
-  BackfillBehavior,
-  BackfillSettings,
-  BufferingStrategy,
-  FieldSelectionRule,
-  FieldSelectionRuleSettings,
-  GroupingSettings,
-  OptimizeSettings,
-  OrphanFilesExpirationSettings,
-  SnapshotExpirationSettings,
-  SourceBufferingSettings,
-  StagingDataSettings,
-  SynapseSourceSettings,
-  TableFormat,
-  TableMaintenanceSettings,
-  TablePropertiesSettings,
-  TargetTableSettings,
-  VersionedDataGraphBuilderSettings
-}
-import com.sneaksanddata.arcane.framework.services.lakehouse.IcebergCatalogCredential
-import com.sneaksanddata.arcane.framework.services.lakehouse.base.{IcebergCatalogSettings, S3CatalogFileIO}
-import com.sneaksanddata.arcane.framework.services.merging.JdbcMergeServiceClientOptions
+import com.sneaksanddata.arcane.framework.models.settings.{BackfillBehavior, BackfillSettings, BufferingStrategy, FieldSelectionRule, FieldSelectionRuleSettings, GroupingSettings, IcebergCatalogSettings, JdbcMergeServiceClientSettings, OptimizeSettings, OrphanFilesExpirationSettings, SnapshotExpirationSettings, SourceBufferingSettings, StagingDataSettings, SynapseSourceSettings, TableFormat, TableMaintenanceSettings, TablePropertiesSettings, TargetTableSettings, VersionedDataGraphBuilderSettings}
+import com.sneaksanddata.arcane.framework.services.iceberg.IcebergCatalogCredential
+import com.sneaksanddata.arcane.framework.services.iceberg.base.S3CatalogFileIO
 import zio.ZLayer
 
 import java.time.format.DateTimeFormatter
@@ -55,7 +36,7 @@ case class MicrosoftSynapseLinkStreamContext(spec: StreamSpec)
     extends StreamContext
     with GroupingSettings
     with IcebergCatalogSettings
-    with JdbcMergeServiceClientOptions
+    with JdbcMergeServiceClientSettings
     with VersionedDataGraphBuilderSettings
     with AzureConnectionSettings
     with TargetTableSettings
@@ -174,7 +155,7 @@ case class MicrosoftSynapseLinkStreamContext(spec: StreamSpec)
 object MicrosoftSynapseLinkStreamContext {
 
   type Environment = StreamContext & GroupingSettings & VersionedDataGraphBuilderSettings & IcebergCatalogSettings &
-    JdbcMergeServiceClientOptions & AzureConnectionSettings & TargetTableSettings & MicrosoftSynapseLinkStreamContext &
+    JdbcMergeServiceClientSettings & AzureConnectionSettings & TargetTableSettings & MicrosoftSynapseLinkStreamContext &
     GraphExecutionSettings & TablePropertiesSettings & FieldSelectionRuleSettings & BackfillSettings &
     StagingDataSettings & SynapseSourceSettings & SourceBufferingSettings
 

--- a/src/main/scala/models/app/MicrosoftSynapseLinkStreamContext.scala
+++ b/src/main/scala/models/app/MicrosoftSynapseLinkStreamContext.scala
@@ -5,7 +5,27 @@ import models.app.contracts.StreamSpec
 
 import com.sneaksanddata.arcane.framework.models.app.StreamContext
 import com.sneaksanddata.arcane.framework.models.settings
-import com.sneaksanddata.arcane.framework.models.settings.{BackfillBehavior, BackfillSettings, BufferingStrategy, FieldSelectionRule, FieldSelectionRuleSettings, GroupingSettings, IcebergCatalogSettings, JdbcMergeServiceClientSettings, OptimizeSettings, OrphanFilesExpirationSettings, SnapshotExpirationSettings, SourceBufferingSettings, StagingDataSettings, SynapseSourceSettings, TableFormat, TableMaintenanceSettings, TablePropertiesSettings, TargetTableSettings, VersionedDataGraphBuilderSettings}
+import com.sneaksanddata.arcane.framework.models.settings.{
+  BackfillBehavior,
+  BackfillSettings,
+  BufferingStrategy,
+  FieldSelectionRule,
+  FieldSelectionRuleSettings,
+  GroupingSettings,
+  IcebergCatalogSettings,
+  JdbcMergeServiceClientSettings,
+  OptimizeSettings,
+  OrphanFilesExpirationSettings,
+  SnapshotExpirationSettings,
+  SourceBufferingSettings,
+  StagingDataSettings,
+  SynapseSourceSettings,
+  TableFormat,
+  TableMaintenanceSettings,
+  TablePropertiesSettings,
+  TargetTableSettings,
+  VersionedDataGraphBuilderSettings
+}
 import com.sneaksanddata.arcane.framework.services.iceberg.IcebergCatalogCredential
 import com.sneaksanddata.arcane.framework.services.iceberg.base.S3CatalogFileIO
 import zio.ZLayer


### PR DESCRIPTION
Fixes #143 

## Scope

Implemented:
- Use framework version with improved fallback timestamp parse algorthm
- Update imports
- Pin LK to 0.8.5